### PR TITLE
Color refactor

### DIFF
--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -103,13 +103,18 @@ function highlightAllRunlengths(vis, runlength, colorA, colorB, size) {
   for (let i = 0; i < size; i++) {
     if (toggle == 0) {
       highlight(vis, i, colorA);
+      console.log("toggle == 0");
     }
     if (toggle == 1) {
       highlight(vis, i, colorB);
+      console.log("toggle == 1");
     }
+    console.log("(i + 1) % runlength = " + (runlength % (i + 1)));
+    console.log("(runlength = " + (runlength));
     // Switch color after completing a run of length 'runlength'
     if ((i + 1) % runlength == 0) {
-      console.log("switching toggle");
+
+      console.log("(i + 1) % runlength == 0");
 
       toggle = 1 - toggle; // Flip toggle between 0 and 1
 
@@ -215,7 +220,7 @@ export function run_msort() {
       displayRunlength(vis, c_rlength, size);
 
       set_simple_stack(vis.array, [c_rlength]);
-      highlightAllRunlengths(vis, runlength, colorA, colorB, size);
+      highlightAllRunlengths(vis, c_rlength, colorA, colorB, size);
     }, [runlength, simple_stack]);
 
     while (runlength < size) {

--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -325,6 +325,8 @@ export function run_msort() {
 
             assignVarToA(vis, 'left', undefined, size); // ap1 replaces left
             assignVarToA(vis, 'ap1', c_ap1, size);
+            assignVarToA(vis, 'mid', c_mid, size);
+            assignVarToA(vis, 'right', c_right, size);
 
           }
         }, [A, ap1, left, mid, right, runlength]);

--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -122,6 +122,32 @@ function highlightAllRunlengths(vis, runlength, colorA, colorB, size) {
   }
 }
 
+// Unhighlight entire array alternating colors for runlength
+function unhighlightAllRunlengths(vis, runlength, colorA, colorB, size) {
+  let toggle = 0; // 0 = colorA, 1 = colorB
+
+  for (let i = 0; i < size; i++) {
+    if (toggle == 0) {
+      unhighlight(vis, i, colorA);
+      console.log("toggle == 0");
+    }
+    if (toggle == 1) {
+      unhighlight(vis, i, colorB);
+      console.log("toggle == 1");
+    }
+    console.log("(i + 1) % runlength = " + (runlength % (i + 1)));
+    console.log("(runlength = " + (runlength));
+    // Switch color after completing a run of length 'runlength'
+    if ((i + 1) % runlength == 0) {
+
+      console.log("(i + 1) % runlength == 0");
+
+      toggle = 1 - toggle; // Flip toggle between 0 and 1
+
+    } console.log("toggle = " + toggle);
+  }
+}
+
 // unhighlights arrayA
 function unhighlight(vis, index, color) {
   if (color == 'red') {
@@ -227,20 +253,25 @@ export function run_msort() {
       let left = 0;
 
       chunker.add('MainWhile', (vis, c_rlength, c_left) => {
+
         // display size label
         assignVarToA(vis, ("size = " + size), size, size);
+
+
+
+      }, [runlength, left]);
+
+      chunker.add('left', (vis, c_left, c_rlength) => {
+        assignVarToA(vis, 'left', c_left, size);
+
+        unhighlightAllRunlengths(vis, c_rlength, colorA, colorB, size);
 
         let left_2 = c_left;
         let mid_2 = (c_rlength + c_left - 1);
         let right_2 = (Math.min(c_rlength * 2, size) - 1);
 
         highlight2Runlength(vis, left_2, mid_2, right_2, colorA, colorB);
-
-      }, [runlength, left]);
-
-      chunker.add('left', (vis, c_left) => {
-        assignVarToA(vis, 'left', c_left, size);
-      }, [left]);
+      }, [left, runlength]);
 
       while ((left + runlength) <= size) {
 
@@ -442,7 +473,7 @@ export function run_msort() {
 
         left = right + 1;
 
-        chunker.add('left2', (vis, old_left, c_left, c_right) => {
+        chunker.add('left2', (vis, old_left, c_left, c_right, c_rlength) => {
           // unhighlight all elements in A
           for (let i = old_left; i <= c_right; i++) {
             unhighlight(vis, i, colorC);
@@ -450,14 +481,22 @@ export function run_msort() {
           if (c_left < size) {
             assignVarToA(vis, 'left', c_left, size);
           }
+          if (c_left + c_rlength >= size) {
+            highlightAllRunlengths(vis, c_rlength * 2, colorA, colorB, size);
 
-        }, [left2, left, right]);
+          }
+
+        }, [left2, left, right, runlength]);
 
       }
 
 
+
+
       runlength = 2 * runlength;
       chunker.add('runlength2', (vis, c_rlength) => {
+
+        // highlightAllRunlengths(vis, c_rlength, colorA, colorB, size);
         assignVarToA(vis, 'left', undefined, size);
         set_simple_stack(vis.array, [c_rlength]);
 

--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -96,6 +96,27 @@ function highlight2Runlength(vis, left, mid, right, colorA, colorB) {
   for (let j = mid + 1; j <= right; j++) highlight(vis, j, colorB);
 }
 
+// Highlight entire array alternating colors for runlength
+function highlightAllRunlengths(vis, runlength, colorA, colorB, size) {
+  let toggle = 0; // 0 = colorA, 1 = colorB
+
+  for (let i = 0; i < size; i++) {
+    if (toggle == 0) {
+      highlight(vis, i, colorA);
+    }
+    if (toggle == 1) {
+      highlight(vis, i, colorB);
+    }
+    // Switch color after completing a run of length 'runlength'
+    if ((i + 1) % runlength == 0) {
+      console.log("switching toggle");
+
+      toggle = 1 - toggle; // Flip toggle between 0 and 1
+
+    } console.log("toggle = " + toggle);
+  }
+}
+
 // unhighlights arrayA
 function unhighlight(vis, index, color) {
   if (color == 'red') {
@@ -146,6 +167,8 @@ function displayMergeLabels(vis, ap1, max1, ap2, max2, bp, size) {
   if (isMergeExpanded()) assignVarToB(vis, 'bp', bp, size);
 }
 
+
+
 function set_simple_stack(vis_array, c_stk) {
   console.log("set_simple_stack" + c_stk);
   console.log(c_stk);
@@ -190,7 +213,9 @@ export function run_msort() {
 
     chunker.add('runlength', (vis, c_rlength) => {
       displayRunlength(vis, c_rlength, size);
+
       set_simple_stack(vis.array, [c_rlength]);
+      highlightAllRunlengths(vis, runlength, colorA, colorB, size);
     }, [runlength, simple_stack]);
 
     while (runlength < size) {

--- a/src/algorithms/pseudocode/msort_arr_bup.js
+++ b/src/algorithms/pseudocode/msort_arr_bup.js
@@ -18,6 +18,7 @@ Mergesort(A, size) \\B Main
     \\Expl}
     \\In{
         merge all consecutive pairs of runs of length runlength \\Ref MergeAll
+        // all consecutive pairs of runs merged \\B merged
         runlength <- runlength * 2 // merging runs doubles the run length \\B runlength2
     \\In}
     // Done \\B Done

--- a/src/algorithms/pseudocode/msort_arr_bup.js
+++ b/src/algorithms/pseudocode/msort_arr_bup.js
@@ -18,7 +18,6 @@ Mergesort(A, size) \\B Main
     \\Expl}
     \\In{
         merge all consecutive pairs of runs of length runlength \\Ref MergeAll
-        // all consecutive pairs of runs merged \\B merged
         runlength <- runlength * 2 // merging runs doubles the run length \\B runlength2
     \\In}
     // Done \\B Done

--- a/src/algorithms/pseudocode/msort_arr_bup.js
+++ b/src/algorithms/pseudocode/msort_arr_bup.js
@@ -39,6 +39,7 @@ MergeAll
         merge A[left..mid] and A[mid+1..right], with the result in A \\Ref MergeCopy
         left <- right + 1 // skip to the next pair of runs (if any) \\B left2
     \\In}
+    // all consecutive pairs of runs merged \\B mergeDone
 \\Code}
 
 \\Note{ 


### PR DESCRIPTION
Implementing changes from the product review from client namely 1. Highlighting consequtive runlengths; 2. Highlighting ap1 and ap2 when they are being compared

1. This should help improve clarity when all the pseudocode is collapsed
<img width="1149" alt="Screenshot 2024-10-01 at 3 19 56 PM" src="https://github.com/user-attachments/assets/0dc25e0b-ba57-4764-9b10-7fd7496d160c">

2. Highlights the ap pointers when comparing
<img width="1154" alt="Screenshot 2024-10-01 at 3 20 40 PM" src="https://github.com/user-attachments/assets/6e4c68e2-d6ac-4239-892c-c72e5eb171c2">
