### PR TITLE
Sprint 3 Client feedback

### DIFF
--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -120,7 +120,7 @@ export function run_msort() {
 
     chunker.add('runlength', (vis, c_rlength) => {
       assignVarToA(vis, "runlength", c_rlength - 1, size);
-      set_simple_stack(vis.array, [c_rlength]);
+      set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
       highlightAllRunlengths(vis, c_rlength, runAColor, runBColor, size);
     }, [runlength]);
 
@@ -135,7 +135,7 @@ export function run_msort() {
       chunker.add('left', (vis, a, c_left, c_rlength) => {
         vis.array.set(a, 'msort_arr_bup'); // unhighlight arrayA
         assignVarToA(vis, 'left', c_left, size);
-        set_simple_stack(vis.array, [c_rlength]);
+        set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
         let left_2 = c_left;
         let mid_2 = (c_rlength + c_left - 1);
         let right_2 = (Math.min(c_rlength * 2, size) - 1);
@@ -307,7 +307,7 @@ export function run_msort() {
 
         chunker.add('copyBA', (vis, a, b, c_left, c_right, c_rlength) => {
           vis.array.set(a, 'msort_arr_bup');
-          set_simple_stack(vis.array, [c_rlength]);
+          set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
 
           if (isMergeExpanded()) vis.arrayB.set(b, 'msort_arr_bup');
 
@@ -320,7 +320,7 @@ export function run_msort() {
 
         chunker.add('left2', (vis, a, c_left, c_rlength) => {
           vis.array.set(a, 'msort_arr_bup'); //unhighlight array a
-          set_simple_stack(vis.array, [c_rlength]);
+          set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
 
           if (c_left < size) assignVarToA(vis, 'left', c_left, size);
 
@@ -345,7 +345,7 @@ export function run_msort() {
       chunker.add('runlength2', (vis, c_rlength) => {
 
         assignVarToA(vis, 'left', undefined, size);
-        set_simple_stack(vis.array, [c_rlength]);
+        set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
 
         if (c_rlength < size) {
           assignVarToA(vis, "runlength", c_rlength - 1, size);
@@ -359,7 +359,7 @@ export function run_msort() {
       for (let i = 0; i < size; i++) {
         highlight(vis, i, sortColor);
       }
-      assignVarToA(vis, 'Done', size, size);
+
       set_simple_stack(vis.array, ["DONE"]);
 
     }, []);

--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -16,7 +16,8 @@ import {
   displayMergeLabels,
   highlightAPointers,
   set_simple_stack,
-  resetArrayA
+  resetArrayA,
+  highlightFromTo
 } from './msort_shared.js';
 
 
@@ -149,13 +150,15 @@ export function run_msort() {
 
         let mid = left + runlength - 1;
         let right = Math.min(mid + runlength, (size - 1));
-        chunker.add('mid', (vis, c_mid) => {
+        chunker.add('mid', (vis, c_mid, c_left) => {
           assignVarToA(vis, 'mid', c_mid, size);
-        }, [mid]);
-        chunker.add('right', (vis, c_right) => {
+          //highlightFromTo(vis, c_left, c_mid, runAColor);
+        }, [mid, left]);
+        chunker.add('right', (vis, c_right, c_mid) => {
           assignVarToA(vis, 'right', c_right, size);
+          //highlightFromTo(vis, c_mid + 1, c_right, runBColor);
 
-        }, [right]);
+        }, [right, mid]);
 
         // start merge[left, mid, right] ------------------------------------------------------------
         let ap1 = left;
@@ -314,15 +317,19 @@ export function run_msort() {
           // highlight all sorted elements green
           for (let i = c_left; i <= c_right; i++) highlight(vis, i, sortColor);
 
+          assignVarToA(vis, "left", c_left, size);
+          assignVarToA(vis, "right", c_right, size);
+
         }, [A, B, left, right, runlength]);
 
         left = right + 1;
 
-        chunker.add('left2', (vis, a, c_left, c_rlength) => {
+        chunker.add('left2', (vis, a, c_left, c_right, c_rlength) => {
           vis.array.set(a, 'msort_arr_bup'); //unhighlight array a
           set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
 
           if (c_left < size) assignVarToA(vis, 'left', c_left, size);
+          assignVarToA(vis, "right", c_right, size);
 
           if ((c_left + c_rlength) < size) {
             let left_2 = c_left;
@@ -330,15 +337,19 @@ export function run_msort() {
             let right_2 = (Math.min((mid_2 + c_rlength + 1), size) - 1);
             highlight2Runlength(vis, left_2, mid_2, right_2, runAColor, runBColor);
           }
+          if ((c_left + c_rlength) >= size) {
+            highlightFromTo(vis, c_left, size - 1, runAColor);
+          }
 
 
-        }, [A, left, runlength]);
+        }, [A, left, right, runlength]);
 
       }
 
       runlength = 2 * runlength;
 
       chunker.add('mergeDone', (vis, c_rlength) => {
+        assignVarToA(vis, "right", undefined, size);
         highlightAllRunlengths(vis, c_rlength, runAColor, runBColor, size);
       }, [runlength])
 

--- a/src/algorithms/controllers/msort_arr_bup.js
+++ b/src/algorithms/controllers/msort_arr_bup.js
@@ -140,7 +140,7 @@ export function run_msort() {
         let left_2 = c_left;
         let mid_2 = (c_rlength + c_left - 1);
         let right_2 = (Math.min(c_rlength * 2, size) - 1);
-        highlight2Runlength(vis, left_2, mid_2, right_2, runAColor, runBColor);
+        // highlight2Runlength(vis, left_2, mid_2, right_2, runAColor, runBColor);
       }, [A, left, runlength]);
 
       while ((left + runlength) <= size) {
@@ -152,11 +152,11 @@ export function run_msort() {
         let right = Math.min(mid + runlength, (size - 1));
         chunker.add('mid', (vis, c_mid, c_left) => {
           assignVarToA(vis, 'mid', c_mid, size);
-          //highlightFromTo(vis, c_left, c_mid, runAColor);
+          highlightFromTo(vis, c_left, c_mid, runAColor);
         }, [mid, left]);
         chunker.add('right', (vis, c_right, c_mid) => {
           assignVarToA(vis, 'right', c_right, size);
-          //highlightFromTo(vis, c_mid + 1, c_right, runBColor);
+          highlightFromTo(vis, c_mid + 1, c_right, runBColor);
 
         }, [right, mid]);
 
@@ -293,7 +293,7 @@ export function run_msort() {
           // future color: should be runAColor & runBColor
           resetArrayA(vis, "bup", a, c_left, c_mid, c_right, c_rlength, runAColor, runCColor);
 
-          if (isMergeExpanded()) vis.arrayB.set(b, 'msort_arr_bup');
+          if (isMergeCopyExpanded()) vis.arrayB.set(b, 'msort_arr_bup');
           assignVarToA(vis, 'ap2', c_ap2, size);
           assignVarToA(vis, 'max2', c_max2, size);
 
@@ -312,9 +312,12 @@ export function run_msort() {
           vis.array.set(a, 'msort_arr_bup');
           set_simple_stack(vis.array, [`runlength = ${c_rlength}`]);
 
-          if (isMergeExpanded()) vis.arrayB.set(b, 'msort_arr_bup');
+          if (isMergeCopyExpanded()) {
+            vis.arrayB.set(b, 'msort_arr_bup');
+          }
 
           // highlight all sorted elements green
+
           for (let i = c_left; i <= c_right; i++) highlight(vis, i, sortColor);
 
           assignVarToA(vis, "left", c_left, size);
@@ -330,17 +333,6 @@ export function run_msort() {
 
           if (c_left < size) assignVarToA(vis, 'left', c_left, size);
           assignVarToA(vis, "right", c_right, size);
-
-          if ((c_left + c_rlength) < size) {
-            let left_2 = c_left;
-            let mid_2 = (c_rlength + c_left - 1);
-            let right_2 = (Math.min((mid_2 + c_rlength + 1), size) - 1);
-            highlight2Runlength(vis, left_2, mid_2, right_2, runAColor, runBColor);
-          }
-          if ((c_left + c_rlength) >= size) {
-            highlightFromTo(vis, c_left, size - 1, runAColor);
-          }
-
 
         }, [A, left, right, runlength]);
 

--- a/src/algorithms/controllers/msort_arr_nat.js
+++ b/src/algorithms/controllers/msort_arr_nat.js
@@ -14,7 +14,8 @@ import {
   displayMergeLabels,
   highlightAPointers,
   set_simple_stack,
-  resetArrayA
+  resetArrayA,
+  highlightFromTo
 } from './msort_shared.js';
 
 const run = run_msort();
@@ -354,20 +355,30 @@ export function run_msort() {
             // highlight all sorted elements green
             for (let i = c_left; i <= c_right; i++) highlight(vis, i, sortColor);
             set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
+
+            assignVarToA(vis, "left", c_left, size);
+            assignVarToA(vis, "right", c_right, size);
+
           }, [A, B, left, right, runcount]);
         }
 
         runcount = runcount + 1;
-        chunker.add('runcount+', (vis, c_rcount) => {
+        chunker.add('runcount+', (vis, c_left, c_mid, c_rcount) => {
+          highlightFromTo(vis, c_left, c_mid, sortColor);
           set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
-        }, [runcount]);
+        }, [left, mid, runcount]);
 
         left = right + 1;
-        chunker.add('left2', (vis, a, c_left, c_rcount) => {
+        chunker.add('left2', (vis, a, c_left, c_right, c_rcount) => {
           vis.array.set(a, 'msort_arr_nat'); // unhighlight array a
           set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
-          if (c_left < size) assignVarToA(vis, 'left', c_left);
-        }, [A, left, runcount]);
+          if (c_left < size) {
+            assignVarToA(vis, 'left', c_left, size);
+            assignVarToA(vis, "right", c_right, size);
+          }
+
+
+        }, [A, left, right, runcount]);
 
       } while (left < size);
 

--- a/src/algorithms/controllers/msort_arr_nat.js
+++ b/src/algorithms/controllers/msort_arr_nat.js
@@ -145,7 +145,8 @@ export function run_msort() {
 
       chunker.add('runcount', (vis, a, c_rcount) => {
         vis.array.set(a, 'msort_arr_nat');
-        set_simple_stack(vis.array, [c_rcount]);
+        set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
+
       }, [A, runcount]);
 
       chunker.add('left', (vis, c_left) => {
@@ -352,19 +353,19 @@ export function run_msort() {
             if (isMergeExpanded()) vis.arrayB.set(b, 'msort_arr_nat');
             // highlight all sorted elements green
             for (let i = c_left; i <= c_right; i++) highlight(vis, i, sortColor);
-            set_simple_stack(vis.array, [c_rcount]);
+            set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
           }, [A, B, left, right, runcount]);
         }
 
         runcount = runcount + 1;
         chunker.add('runcount+', (vis, c_rcount) => {
-          set_simple_stack(vis.array, [c_rcount]);
+          set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
         }, [runcount]);
 
         left = right + 1;
         chunker.add('left2', (vis, a, c_left, c_rcount) => {
           vis.array.set(a, 'msort_arr_nat'); // unhighlight array a
-          set_simple_stack(vis.array, [c_rcount]);
+          set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);
           if (c_left < size) assignVarToA(vis, 'left', c_left);
         }, [A, left, runcount]);
 

--- a/src/algorithms/controllers/msort_arr_nat.js
+++ b/src/algorithms/controllers/msort_arr_nat.js
@@ -337,7 +337,7 @@ export function run_msort() {
           chunker.add('CopyRest2', (vis, a, b, c_ap2, c_max2, c_left, c_right, c_mid, c_rcount) => {
             // future color: should be runAColor & runBColor
             resetArrayA(vis, "nat", a, c_left, c_mid, c_right, c_rcount, runAColor, runCColor);
-            if (isMergeExpanded()) vis.arrayB.set(b, 'msort_arr_nat');
+            if (isMergeCopyExpanded()) vis.arrayB.set(b, 'msort_arr_nat');
             assignVarToA(vis, 'ap2', c_ap2, size);
             assignVarToA(vis, 'max2', c_max2, size);
             // highlight sorted elements green
@@ -351,7 +351,7 @@ export function run_msort() {
           }
           chunker.add('copyBA', (vis, a, b, c_left, c_right, c_rcount) => {
             vis.array.set(a, 'msort_arr_nat');
-            if (isMergeExpanded()) vis.arrayB.set(b, 'msort_arr_nat');
+            if (isMergeCopyExpanded()) vis.arrayB.set(b, 'msort_arr_nat');
             // highlight all sorted elements green
             for (let i = c_left; i <= c_right; i++) highlight(vis, i, sortColor);
             set_simple_stack(vis.array, [`runcount = ${c_rcount}`]);

--- a/src/algorithms/controllers/msort_arr_nat.js
+++ b/src/algorithms/controllers/msort_arr_nat.js
@@ -66,6 +66,33 @@ export function initVisualisers() {
 // Define helper functions
 // -------------------------------------------------------------------------------
 
+// This function highlights all the runs alternating colours, kudos to chatgpt
+function highlightNaturalRuns(vis, array, runAColor, runBColor) {
+  let toggle = 0; // 0 = runAColor, 1 = runBColor
+  let i = 0;
+
+  while (i < array.length) {
+    let start = i;
+
+    // Find the length of the increasing run
+    while (i < array.length - 1 && array[i] <= array[i + 1]) {
+      i++;
+    }
+
+    // Highlight the run
+    for (let j = start; j <= i; j++) {
+      highlight(vis, j, toggle == 0 ? runAColor : runBColor);
+    }
+
+    // Flip toggle between 0 and 1 for the next run
+    toggle = 1 - toggle;
+
+    // Move to the next element after the current run
+    i++;
+  }
+}
+
+
 
 
 /**
@@ -106,18 +133,20 @@ export function run_msort() {
 
     do {
 
-      chunker.add('MainWhile', () => {
+      chunker.add('MainWhile', (vis, a) => {
         // no animation
-      }, []);
+        highlightNaturalRuns(vis, a, runAColor, runBColor);
+      }, [A]);
 
 
 
       runcount = 0;
       let left = 0;
 
-      chunker.add('runcount', (vis, c_rcount) => {
+      chunker.add('runcount', (vis, a, c_rcount) => {
+        vis.array.set(a, 'msort_arr_nat');
         set_simple_stack(vis.array, [c_rcount]);
-      }, [runcount]);
+      }, [A, runcount]);
 
       chunker.add('left', (vis, c_left) => {
         assignVarToA(vis, 'left', c_left, size);
@@ -340,13 +369,21 @@ export function run_msort() {
         }, [A, left, runcount]);
 
       } while (left < size);
+
+      chunker.add('mergeDone', (vis, a) => {
+        highlightNaturalRuns(vis, a, runAColor, runBColor);
+      }, [A])
+
     } while (runcount > 1);
 
-    chunker.add('Done', (vis) => {
-      for (let i = 0; i < size; i++) highlight(vis, i, "sortColor");
-      assignVarToA(vis, 'Done', size, size);
+    chunker.add('Done', (vis, a) => {
+      vis.array.set(a, 'msort_arr_nat');
+      for (let i = 0; i < size; i++) {
+        highlight(vis, i, sortColor);
+      }
+
       set_simple_stack(vis.array, ["DONE"]);
-    }, []);
+    }, [A]);
 
     const maxValue = entire_num_array.reduce((acc, curr) => (acc < curr ? curr : acc), 0);
 

--- a/src/algorithms/controllers/msort_shared.js
+++ b/src/algorithms/controllers/msort_shared.js
@@ -49,6 +49,14 @@ export function unhighlight(vis, index, color) {
     }
 }
 
+// Highlights one runlength 
+export function highlightFromTo(vis, from, to, color) {
+    // highlight first runlength color A
+    for (let i = from; i <= to; i++) {
+        highlight(vis, i, color);
+    }
+}
+
 // Highlights two runlengths two colours
 export function highlight2Runlength(vis, left, mid, right, colorA, colorB) {
     // highlight first runlength color A

--- a/src/algorithms/controllers/msort_shared.js
+++ b/src/algorithms/controllers/msort_shared.js
@@ -29,7 +29,7 @@ export function highlight(vis, index, color) {
 
 // Same as highlight() but checks isMergeExpanded()/arrayB is displayed, otherwise does nothing
 export function highlightB(vis, index, color) {
-    if (isMergeExpanded()) {
+    if (isMergeCopyExpanded()) {
         if (color == 'red') {
             vis.arrayB.select(index);
         }

--- a/src/algorithms/controllers/msort_shared.js
+++ b/src/algorithms/controllers/msort_shared.js
@@ -111,5 +111,8 @@ export function resetArrayA(vis, arr_type, A, left, mid, right, stack, colorA, c
     if (arr_type === "nat") vis.array.set(A, 'msort_arr_nat');
 
     highlight2Runlength(vis, left, mid, right, colorA, colorB);
-    set_simple_stack(vis.array, [stack]);
+
+
+    if (arr_type === "bup") set_simple_stack(vis.array, [`runlength = ${stack}`]);
+    if (arr_type === "nat") set_simple_stack(vis.array, [`runcount = ${stack}`]);
 }

--- a/src/algorithms/controllers/msort_shared.js
+++ b/src/algorithms/controllers/msort_shared.js
@@ -26,6 +26,7 @@ export function highlight(vis, index, color) {
         vis.array.patch(index);
     }
 }
+
 // Same as highlight() but checks isMergeExpanded()/arrayB is displayed, otherwise does nothing
 export function highlightB(vis, index, color) {
     if (isMergeExpanded()) {

--- a/src/algorithms/pseudocode/msort_arr_nat.js
+++ b/src/algorithms/pseudocode/msort_arr_nat.js
@@ -49,6 +49,7 @@ MergeAll
         left <- right + 1 // skip to the next pair of runs (if any) \\B left2
     until left >= size
     \\In}
+    // all consecutive pairs of runs merged \\B mergeDone
 \\Code}
 
 \\Code{

--- a/src/components/DataStructures/Array/Array1DRenderer/index.js
+++ b/src/components/DataStructures/Array/Array1DRenderer/index.js
@@ -228,14 +228,14 @@ class Array1DRenderer extends Array2DRenderer {
             <caption
               className={styles.captionmsort_arr_bup}
               kth-tag="msort_arr_bup_caption"
-            > runlength = &emsp; {listOfNumbers}&emsp;&emsp; </caption>)
+            > &emsp; {listOfNumbers}&emsp;&emsp; </caption>)
         }
         {
           algo === 'msort_arr_nat' && listOfNumbers && (
             <caption
               className={styles.captionmsort_arr_nat}
               kth-tag="msort_arr_nat_caption"
-            > runcount = &emsp; {listOfNumbers}&emsp;&emsp; </caption>)
+            > &emsp; {listOfNumbers}&emsp;&emsp; </caption>)
         }
       </table>
     );


### PR DESCRIPTION
Show `left ← right + 1` shows "left" and "right" labels and also when "copyBA
<img width="659" alt="Screenshot 2024-10-14 at 1 01 26 AM" src="https://github.com/user-attachments/assets/45b6f2b5-54a5-4f98-898b-bf4bc93269ce">

Merge(A, left, mid, right, B) when collapsed (but outer llevel is expanded), array B should appear with the sorted run in it
<img width="719" alt="Screenshot 2024-10-14 at 1 55 44 PM" src="https://github.com/user-attachments/assets/ce10439a-7d9b-49b9-870a-359f3afabbf1">

at the end omit “runcount/runlength =” and just have “DONE”, plus remove the smaller “Done”
<img width="718" alt="Screenshot 2024-10-14 at 1 09 21 AM" src="https://github.com/user-attachments/assets/6196683e-42d7-4090-8409-1991d80e14f9">


colours for natural merge sort
<img width="722" alt="Screenshot 2024-10-14 at 1 57 03 PM" src="https://github.com/user-attachments/assets/9d30c7a4-d793-4f86-a04a-7cd9e9b41d20">
